### PR TITLE
cli: Treat an empty syncfolder as not configured

### DIFF
--- a/crates/cli/src/alfred.rs
+++ b/crates/cli/src/alfred.rs
@@ -97,9 +97,12 @@ fn sync_directory() -> Result<PathBuf> {
         .into_dictionary()
         .context("expected dictionary")?
         .remove("syncfolder")
+        .map(|dir| dir.into_string().context("expected string"))
+        .transpose()?
+        .filter(|dir| !dir.trim().is_empty())
     {
         Some(dir) => {
-            let dir = PathBuf::from(dir.into_string().context("expected string")?);
+            let dir = PathBuf::from(dir);
             if let Ok(p) = dir.strip_prefix("~") {
                 home.join(p)
             } else {


### PR DESCRIPTION
My `syncfolder` is set to an empty string.
I believe I had sync configured once and removed the folder since,
leaving me with an empty string.

This PR ignores empty strings and treats them as unconfigured.
Without that PR, the `workspaces` folder would be resolved
relative to the current dir, leading to file-not-found errors down the line.
