### PR TITLE
cli: Default to unstripped dst if target dir is outside of current dir

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -187,7 +187,9 @@ fn package() -> Result<()> {
         "Packaged",
         format!(
             "workflow at `{}`",
-            dst.strip_prefix(env::current_dir()?)?.display()
+            dst.strip_prefix(env::current_dir()?)
+                .unwrap_or(dst)
+                .display()
         ),
     );
 


### PR DESCRIPTION
One could configure shared target-dir for cargo, for example:

```bash
❯ cat ~/.cargo/config.toml
[build]
target-dir = "/tmp/rustc-target-dir"
```

Which means that the packaged workflow is not in a subfolder of the current folder
and stripping the current folder as prefix results in an error.

This PR falls back to printing the full path in that case, for example:

```
❯ powerpack package
    Finished release [optimized] target(s) in 0.13s
    Replaced binary at `workflow/alfred-test`
    Packaged workflow at `/tmp/rustc-target-dir/workflow/alfred-test.alfredworkflow`
```
